### PR TITLE
Added Pulp logger for java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+#### Simple Project about rating teachers.
+
+* Installation:
+
+```bash
+git clone https://github.com/mahdi-malv/OstadRate.git
+# Run with android studio
+cd Ostadrate
+studio .
+```
+
+Class `Pulp` is a simple logger utility.
+
+#### Usage
+
+```java
+Pulp.info(TAG, message);
+```
+
+```java
+Pulp.info(TAG, message, throwable);
+```
+
+```java
+Pulp.info(TAG, message,
+    key1, message1,
+    key2, message2);
+```
+
+```java
+Pulp.info(TAG, message)
+   .addMessage(key1, message1)
+   .addMessage(key2, message2)
+   .log();
+```
+
+#### Main tag
+
+The tag to identify logs inside logcat.
+
+```java
+Pulp.setMainTag(appLogTag);
+```
+
+#### Log listener
+
+To add a listener to get callback while Pulp was triggered:
+
+```java
+Pulp.addHandler(new Pulp.LogHandler() {
+    @Override
+    public void onLog(Pulp.LogLevel logLevel, String tag, String message, Throwable throwable, Map<String, String> data) {
+         // Use log data             
+    }
+});
+```
+It is possible to have multiple handlers.<br>
+To remove all handlers:
+
+```java
+Pulp.clearHandlers();
+```
+
+#### Enable / Disable log
+
+```java
+Pulp.setLogEnabled(true);
+Pulp.setHandlerEnabled(true);
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#### Simple Project about rating teachers.
+## Simple Project about rating teachers.
 
-* Installation:
+## Installation:
 
 ```bash
 git clone https://github.com/mahdi-malv/OstadRate.git
@@ -9,7 +9,7 @@ cd Ostadrate
 studio .
 ```
 
-Class `Pulp` is a simple logger utility.
+### Class `Pulp` is a simple logger utility.
 
 #### Usage
 
@@ -33,6 +33,8 @@ Pulp.info(TAG, message)
    .addMessage(key2, message2)
    .log();
 ```
+
+> Different log levels are `info`, `debug`, `warn`, `error` and `wtf`.
 
 #### Main tag
 

--- a/app/src/main/java/com/example/ostadrate/logger/Pulp.java
+++ b/app/src/main/java/com/example/ostadrate/logger/Pulp.java
@@ -32,7 +32,7 @@ public class Pulp {
         handlers.add(handler);
     }
 
-    public static void clearhandlers(){
+    public static void clearHandlers(){
         handlers.clear();
     }
 
@@ -212,7 +212,7 @@ public class Pulp {
     }
 
 
-    private enum LogLevel {
+    public enum LogLevel {
         INFO,
         DEBUG,
         WARN,

--- a/app/src/main/java/com/example/ostadrate/logger/Pulp.java
+++ b/app/src/main/java/com/example/ostadrate/logger/Pulp.java
@@ -1,9 +1,15 @@
 package com.example.ostadrate.logger;
 
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class Pulp {
+
+    // ------ Configuration
 
     private static boolean isLogEnabled = true;
     private static boolean isLogHandlerEnabled = true;
@@ -31,17 +37,179 @@ public class Pulp {
     }
 
 
-    public static void info(String tag, String message, String throwable, String... data) {
+    // ------ LOGGER methods
+
+    public static void info(String tag, String message, Throwable throwable, String... data) {
+        log(LogLevel.INFO, tag, message, throwable, data);
     }
 
     public static void info(String tag, String message, String... data) {
+        info(tag, message, null, data);
     }
 
-
-    private void log(LogLevel logLevel, String tag, String message, Throwable throwable, String... data) {
-
+    public static LogData info(String tag, String message, Throwable throwable) {
+        return new LogData(LogLevel.INFO, tag, message, throwable);
     }
 
+    public static LogData info(String tag, String message) {
+        return new LogData(LogLevel.INFO, tag, message, null);
+    }
+
+    public static void debug(String tag, String message, Throwable throwable, String... data) {
+        log(LogLevel.DEBUG, tag, message, throwable, data);
+    }
+
+    public static void debug(String tag, String message, String... data) {
+        debug(tag, message, null, data);
+    }
+
+    public static LogData debug(String tag, String message, Throwable throwable) {
+        return new LogData(LogLevel.DEBUG, tag, message, throwable);
+    }
+
+    public static LogData debug(String tag, String message) {
+        return new LogData(LogLevel.DEBUG, tag, message, null);
+    }
+
+    public static void warn(String tag, String message, Throwable throwable, String... data) {
+        log(LogLevel.WARN, tag, message, throwable, data);
+    }
+
+    public static void warn(String tag, String message, String... data) {
+        warn(tag, message, null, data);
+    }
+
+    public static LogData warn(String tag, String message, Throwable throwable) {
+        return new LogData(LogLevel.WARN, tag, message, throwable);
+    }
+
+    public static LogData warn(String tag, String message) {
+        return new LogData(LogLevel.WARN, tag, message, null);
+    }
+
+    public static void error(String tag, String message, Throwable throwable, String... data) {
+        log(LogLevel.ERROR, tag, message, throwable, data);
+    }
+
+    public static void error(String tag, String message, String... data) {
+        error(tag, message, null, data);
+    }
+
+    public static LogData error(String tag, String message, Throwable throwable) {
+        return new LogData(LogLevel.ERROR, tag, message, throwable);
+    }
+
+    public static LogData error(String tag, String message) {
+        return new LogData(LogLevel.ERROR, tag, message, null);
+    }
+
+    public static void wtf(String tag, String message, Throwable throwable, String... data) {
+        log(LogLevel.WTF, tag, message, throwable, data);
+    }
+
+    public static void wtf(String tag, String message, String... data) {
+        wtf(tag, message, null, data);
+    }
+
+    public static LogData wtf(String tag, String message, Throwable throwable) {
+        return new LogData(LogLevel.WTF, tag, message, throwable);
+    }
+
+    public static LogData wtf(String tag, String message) {
+        return new LogData(LogLevel.WTF, tag, message, null);
+    }
+
+    // ------ Experimental log data class
+
+    public static class LogData {
+        private LogLevel level;
+        private String tag, message;
+        private Throwable throwable;
+        private Map<String, String> data = new HashMap<>();
+
+        public LogData(LogLevel level, String tag, String message, Throwable throwable) {
+            this.level = level;
+            this.tag = tag;
+            this.message = message;
+            this.throwable = throwable;
+        }
+
+        public LogData addMessage(String key, String message) {
+            data.put(key, message);
+            return this;
+        }
+
+        public void log() {
+            Pulp.log(level, tag, message, throwable, data);
+        }
+    }
+
+    // ------ Log utilities
+
+    private static void log(LogLevel logLevel, String tag, String message, Throwable throwable, String... data) {
+        if (!isLogEnabled) return;
+        Map<String, String> map = getMap(data);
+        log(logLevel, tag, message, throwable, map);
+    }
+
+    private static void log(LogLevel logLevel, String tag, String message, Throwable throwable, Map<String, String> map) {
+        if (!isLogEnabled) return;
+        String text = getMessage(tag, message, map);
+        if (isLogHandlerEnabled) {
+            for (LogHandler handler : handlers) {
+                handler.onLog(logLevel, tag, message, throwable, map);
+            }
+        }
+        switch (logLevel) {
+            case INFO:
+                if (throwable == null) Log.i(mainTag, text);
+                else Log.i(mainTag, text, throwable);
+                break;
+            case DEBUG:
+                if (throwable == null) Log.d(mainTag, text);
+                else Log.d(mainTag, text, throwable);
+                break;
+            case WARN:
+                if (throwable == null) Log.w(mainTag, text);
+                else Log.w(mainTag, text, throwable);
+                break;
+            case ERROR:
+                if (throwable == null) Log.e(mainTag, text);
+                else Log.e(mainTag, text, throwable);
+                break;
+            case WTF:
+                if (throwable == null) Log.wtf(mainTag, text);
+                else Log.wtf(mainTag, text, throwable);
+                break;
+        }
+    }
+
+    private static Map<String, String> getMap(String... data) {
+        Map<String, String> extraData = new HashMap<>();
+        if (data.length != 0) {
+            for (int i = 0; i < data.length; i++) {
+                if (i + 1 < data.length) {
+                    extraData.put(data[i], data[i+1]);
+                } else {
+                    extraData.put(data[i], "None");
+                }
+                i++;
+            }
+        }
+        return extraData;
+    }
+
+    private static String getMessage(String tag, String message, Map<String, String> data) {
+        StringBuilder text = new StringBuilder("Tag: \n" + tag + "\n" +
+                "Message: " + message + "\n");
+        if (data.size() != 0) {
+            text.append("Data:\n");
+        }
+        for (Map.Entry<String, String> item : data.entrySet()) {
+            text.append("\n").append(item.getKey()).append(":\t").append(item.getValue());
+        }
+        return text.toString();
+    }
 
 
     private enum LogLevel {

--- a/app/src/main/java/com/example/ostadrate/pages/RateTeacherActivity.java
+++ b/app/src/main/java/com/example/ostadrate/pages/RateTeacherActivity.java
@@ -17,10 +17,12 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.ostadrate.R;
 import com.example.ostadrate.Teacher;
+import com.example.ostadrate.logger.Pulp;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import de.hdodenhof.circleimageview.CircleImageView;
 


### PR DESCRIPTION
Pulp is a logger that used to be for Kotlin only. This branch includes `Pulp` logger for java.

#### Usage:

```java
Pulp.info("TAG", "message", throwable,
   "key", "message",
    "key2", "message2");

// Or

Pulp.info("TAG", "message", throwable)
    .addMessage("key", "message")
    .addMessage("key1", "messag1")
    .log();
```